### PR TITLE
allow Product#really_destroy!

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -249,7 +249,8 @@ module Spree
       end
 
       def punch_permalink
-        update_attribute :permalink, "#{Time.now.to_i}_#{permalink}" # punch permalink with date prefix
+        # punch permalink with date prefix
+        update_attribute :permalink, "#{Time.now.to_i}_#{permalink}" unless frozen?
       end
   end
 end


### PR DESCRIPTION
this fixes the use of `paranoia` gem's `really_destroy!` method, otherwise we get:

```
RuntimeError: can't modify frozen Hash
...
    from .../gems/spree_core-2.4.4/app/models/spree/product.rb:266:in `punch_slug'
```
